### PR TITLE
add wrap model hook return

### DIFF
--- a/ember-style-guide.md
+++ b/ember-style-guide.md
@@ -309,6 +309,9 @@ Bad
 model (params) {
   return this.store.findRecord('user', params.user_id)
 }
+
+Acceptable: No route file because the model is automatically found via a dynamic segment in the url.
+
 ```
 
 Good

--- a/ember-style-guide.md
+++ b/ember-style-guide.md
@@ -314,7 +314,7 @@ model (params) {
 Good
 ```javascript
 model (params) {
-  return {
+  return Ember.RSVP.hash({
     user: this.store.findRecord('user', params.user_id)
   }
 }

--- a/ember-style-guide.md
+++ b/ember-style-guide.md
@@ -297,6 +297,27 @@ export function formatDate (date, format) {
 
 ```
 
+### Always wrap model hook return value in an object
+Having a value as the return type makes future maintenace of templates clumsy, error prone, and makes the templates less descriptive.
+
+Routes should be simple enough to only require one model (preferably automagically specified by a dynamic route segment), but currently this is often not the case.
+
+Bad
+```javascript
+model (params) {
+  return this.store.findRecord('user', params.user_id)
+}
+```
+
+Good
+```javascript
+model (params) {
+  return {
+    user: this.store.findRecord('user', params.user_id)
+  }
+}
+```
+
 ### Services
 
 1. Use a service for any global application state

--- a/ember-style-guide.md
+++ b/ember-style-guide.md
@@ -298,9 +298,11 @@ export function formatDate (date, format) {
 ```
 
 ### Always wrap model hook return value in an object
-Having a value as the return type makes future maintenace of templates clumsy, error prone, and makes the templates less descriptive.
+#### Praise
+Wrapping the value makes template variables more descriptive and makes adding new models easy.
 
-Routes should be simple enough to only require one model (preferably automagically specified by a dynamic route segment), but currently this is often not the case.
+#### Criticism
+Routes *should* be simple enough to only require one model, preferably automagically specified by a dynamic route segment, but this is often not the case.
 
 Bad
 ```javascript


### PR DESCRIPTION
This may be controversial and I am happy not having it added in :).

I've recently had to modify a number of model hooks that exposed a single value and found the transition needlessly painful when all values could have been wrapped in an object up front, made the templates clearer, and the model easier to modify in the future.

The downside I can see here is that automagically generated model hooks that take advantage of dynamic route segments will not work like this.