### PR TITLE
add use save and exact by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ with EmberCLI for frontend transpilation
 
 [node-standard-style](https://github.com/feross/standard)
 
+Don't forget to set:
+```bash
+npm config set save=true
+npm config set save-exact=true
+```
+
 ### Hosting
 
 


### PR DESCRIPTION
Sick of forgetting to type --save at the end of every npm install, not sure if we use patch versions of libraries? Fear no more, company-wide default npm config settings are here!
