### PR TITLE
Recommendations about loopback prototype methods for custom end-points

### DIFF
--- a/loopback-style-guide.md
+++ b/loopback-style-guide.md
@@ -1,7 +1,7 @@
 # Media Suite Emberjs Style Guide
 
 ## Prototype over static functions in model Custom Routes
-                                 
+
 * We should prefer using prototype model methods over static methods when tying to a custom end-point. Consider this static declaration route:
 
 ```javascript
@@ -29,7 +29,7 @@
        ...
 ```
 
-* In this example, we are required to look up the target model as one of the first operations of the method, and then check this was a valid model. 
+* In this example, we are required to look up the target model as one of the first operations of the method, and then check this was a valid model.
 * All this can be handled for us if we use prototype methods, in the following structure:
 
 ```javascript
@@ -44,7 +44,6 @@
  })
 
  Worksite.prototype.startWork = function (data, cb) {
-   const worksite = this
    ...
 ```
 
@@ -52,7 +51,6 @@
 * This mechanism reduces the code required in your Model methods.
 * **Note** It is important to use traditional function declarations over ES6 arrow functions when declaring your prototype, otherwise the `this` keyword will not have the correct context.
 I.e.
-* Convention: assign the model name to this as the first line of the method.
 * slc generator is useful here `slc loopback:remote-method`
 
 ```javascript
@@ -64,7 +62,7 @@ Not
 ```javascript
 Worksite.prototype.startWork = (data, cb) => {
 ```
-                                 
+
 ## Things to be aware of with Loopback and Postgres
 So I ran a sql injection fuzzer https://github.com/sqlmapproject/sqlmap on the search endpoint to see what I could dig up. As far as I can tell there was no successful injection - but I did uncover two crashes at the pg level, so the takeaway is:
 

--- a/loopback-style-guide.md
+++ b/loopback-style-guide.md
@@ -44,7 +44,7 @@
  })
 
  Worksite.prototype.startWork = function (data, cb) {
-   // 'this' -> is the worksite
+   const worksite = this
    ...
 ```
 
@@ -52,6 +52,7 @@
 * This mechanism reduces the code required in your Model methods.
 * **Note** It is important to use traditional function declarations over ES6 arrow functions when declaring your prototype, otherwise the `this` keyword will not have the correct context.
 I.e.
+* Convention: assign the model name to this as the first line of the method.
 
 ```javascript
 Worksite.prototype.startWork = function (data, cb) {

--- a/loopback-style-guide.md
+++ b/loopback-style-guide.md
@@ -53,6 +53,7 @@
 * **Note** It is important to use traditional function declarations over ES6 arrow functions when declaring your prototype, otherwise the `this` keyword will not have the correct context.
 I.e.
 * Convention: assign the model name to this as the first line of the method.
+* slc generator is useful here `slc loopback:remote-method`
 
 ```javascript
 Worksite.prototype.startWork = function (data, cb) {

--- a/loopback-style-guide.md
+++ b/loopback-style-guide.md
@@ -1,3 +1,69 @@
+# Media Suite Emberjs Style Guide
+
+## Prototype over static functions in model Custom Routes
+                                 
+* We should prefer using prototype model methods over static methods when tying to a custom end-point. Consider this static declaration route:
+
+```javascript
+ Worksite.remoteMethod('startWork', {
+   accepts: [
+     {arg: 'id', type: 'number', required: true},
+     {arg: 'data', type: 'object', http: {source: 'body'}}
+   ],
+   returns: {type: 'Worksite', root: true},
+   http: {path: '/:id/start-work', verb: 'post', status: 200}
+ })
+```
+
+* By default this is a going to tie to a static method that would probably look a little like this:
+
+```javascript
+ WorksiteSubmission.startWork = function (id, data, cb) {
+   WorksiteSubmission.findById(id)
+     .then(worksite => {
+       if (!worksite) {
+         const err = new Error('No worksite found')
+         err.status = 404
+         cb(err)
+       }
+       ...
+```
+
+* In this example, we are required to look up the target model as one of the first operations of the method, and then check this was a valid model. 
+* All this can be handled for us if we use prototype methods, in the following structure:
+
+```javascript
+ Worksite.remoteMethod('startWork', {
+   accepts: [
+     {arg: 'id', type: 'number', required: true},
+     {arg: 'data', type: 'object', http: {source: 'body'}}
+   ],
+   isStatic: false,
+   returns: {type: 'Worksite', root: true},
+   http: {path: '/start-work', verb: 'post', status: 200}
+ })
+
+ Worksite.prototype.startWork = function (data, cb) {
+   // 'this' -> is the worksite
+   ...
+```
+
+* In this example, `this` is the worksite, and a failure to find a worksite matching the supplied Id returns a 404 before it hits this method.
+* This mechanism reduces the code required in your Model methods.
+* **Note** It is important to use traditional function declarations over ES6 arrow functions when declaring your prototype, otherwise the `this` keyword will not have the correct context.
+I.e.
+
+```javascript
+Worksite.prototype.startWork = function (data, cb) {
+```
+
+Not
+
+```javascript
+Worksite.prototype.startWork = (data, cb) => {
+```
+                                 
+## Things to be aware of with Loopback and Postgres
 So I ran a sql injection fuzzer https://github.com/sqlmapproject/sqlmap on the search endpoint to see what I could dig up. As far as I can tell there was no successful injection - but I did uncover two crashes at the pg level, so the takeaway is:
 
 > Loopback DOES prepare the statements, passing them to the pg lib, which as far as I can tell passes them over the pg connection and lets pg do the preparing


### PR DESCRIPTION
I think we should favour prototype over static methods for Model endpoints where we are passing in an :id argument.

This PR is for discussion around that topic.